### PR TITLE
add multidomain behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,12 @@ don't have webserver running so you can select port 80 or 443.
             enabled: true
           www.dummy.org:
             enabled: true
+          # Following will produce multidomain certificate:
+          site.dummy.org:
+            enabled: true
+            names:
+              - dummy.org
+              - www.dummy.org
 
 However ACME server always visits port 80 (or 443) where most likely Apache or
 Nginx is listening. This means that you need to configure
@@ -138,6 +144,39 @@ domain:
               port: 80
           www.dummy.org:
             enabled: true
+
+You are able to use multidomain certificates:
+
+.. code-block:: yaml
+
+    letsencrypt:
+      client:
+        email: sylvain@home
+        staging: true
+        auth:
+          method: apache
+        domain:
+          keynotdomain:
+            enabled: true
+            name: ls.opensource-expert.com
+            names:
+            - www.ls.opensource-expert.com
+            - vim22.opensource-expert.com
+            - www.vim22.opensource-expert.com
+          rm.opensource-expert.com:
+            enabled: true
+            names:
+            - www.rm.opensource-expert.com
+          vim7.opensource-expert.com:
+            enabled: true
+            names:
+            - www.vim7.opensource-expert.com
+          vim88.opensource-expert.com:
+            enabled: true
+            names:
+            - www.vim88.opensource-expert.com
+            - awk.opensource-expert.com
+            - www.awk.opensource-expert.com
 
 Legacy configuration
 --------------------

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -23,7 +23,7 @@ certbot_{{ domain }}:
         --{{ auth.method }}
         {%- endif %}
         -d {{ params.name|default(domain) }}
-        {%- for d in params.get('multi', []) %}
+        {%- for d in params.get('names', []) %}
         -d {{ d }}
         {%- endfor %}
     - creates: {{ client.conf_dir }}/live/{{ params.name|default(domain) }}/cert.pem

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -1,5 +1,12 @@
 {%- from "letsencrypt/map.jinja" import client with context %}
 
+{#- global staging #}
+{%- if client.get('staging', false) %}
+{%-   set staging = '--staging' %}
+{%- else %}
+{%-   set staging = '' %}
+{%- endif %}
+
 {%- for domain, params in client.get('domain', {}).iteritems() %}
 {%- if params.get('enabled', true) %}
 {%- set auth = params.auth|default(client.auth) %}
@@ -7,7 +14,7 @@
 certbot_{{ domain }}:
   cmd.run:
     - name: >
-        certbot certonly --non-interactive --agree-tos --no-self-upgrade --email {{ params.email|default(client.email) }}
+        certbot certonly {{ staging }} --non-interactive --agree-tos --no-self-upgrade --email {{ params.email|default(client.email) }}
         {%- if auth.method == 'standalone' %}
         --standalone --standalone-supported-challenges {{ auth.type }} --http-01-port {{ auth.port }}
         {%- elif auth.method == 'webroot' %}
@@ -16,6 +23,9 @@ certbot_{{ domain }}:
         --{{ auth.method }}
         {%- endif %}
         -d {{ params.name|default(domain) }}
+        {%- for d in params.get('multi', []) %}
+        -d {{ d }}
+        {%- endfor %}
     - creates: {{ client.conf_dir }}/live/{{ params.name|default(domain) }}/cert.pem
     - require:
       - cmd: certbot_installed


### PR DESCRIPTION
I needed to have multidomain for my website in the same certificate.

I did it that way, via a `multi:` key in the domain. I also added a `staging:` true to select certbot staging for development:

https://letsencrypt.org/docs/staging-environment/

pillar:

~~~yaml
letsencrypt:
  client:
    email: sylvain@home
    staging: true
    auth:
      method: apache
    domain:
      ls.opensource-expert.com:
        enabled: true
        multi:
        - www.ls.opensource-expert.com
        - vim22.opensource-expert.com
        - www.vim22.opensource-expert.com
      rm.opensource-expert.com:
        enabled: true
        multi:
        - www.rm.opensource-expert.com
      vim7.opensource-expert.com:
        enabled: true
        multi:
        - www.vim7.opensource-expert.com
      vim88.opensource-expert.com:
        enabled: true
        multi:
        - www.vim88.opensource-expert.com
        - awk.opensource-expert.com
        - www.awk.opensource-expert.com
~~~