### PR TITLE
Do not deploy systemd unit files when using distribution package

### DIFF
--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -53,7 +53,7 @@ certbot_installed:
 
 {%- if grains.get('init', None) == 'systemd' %}
 
-{%- if client.source.engine == 'pkg' %}
+{%- if client.source.engine != 'pkg' %}
 certbot_service:
   file.managed:
     - name: /etc/systemd/system/certbot.service


### PR DESCRIPTION
If 'pkg' source is used, there is no need to deploy systemd unit files, because they are already there:

```
dpkg -S /lib/systemd/system/certbot.*
certbot: /lib/systemd/system/certbot.service
certbot: /lib/systemd/system/certbot.timer
```
Fixes #6