### PR TITLE
Reload systemd service when unit file is changed

### DIFF
--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -60,6 +60,16 @@ certbot_service:
     - source: salt://letsencrypt/files/certbot.service
     - template: jinja
 
+{# reload systemd unit file when it changes #}
+certbot_service_available:
+  module.watch:
+    - name: service.available
+    - m_name: certbot.service
+    - require:
+      - file: certbot_service
+    - watch:
+      - file: certbot_service
+  
 certbot_timer:
   file.managed:
     - name: /etc/systemd/system/certbot.timer


### PR DESCRIPTION
If '/etc/systemd/system/certbot.service` file is changed, running service produces this warning by systemd:
```
Warning: Unit file of certbot.service changed on disk, 'systemctl daemon-reload' recommended
```
This can be fixed using `service.available` execution module. `service.running` state module does not work with `oneshot` services (because they are always "dead").