### PR TITLE
Fix typo in service.running state

### DIFF
--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -84,7 +84,7 @@ certbot_timer:
 certbot_timer_enabled:
   service.running:
     - name: certbot.timer
-    - enabled: true
+    - enable: true
     - require:
       - cmd: certbot_installed
 


### PR DESCRIPTION
Change "enabled" to "enable".