### PR TITLE
Fix certbot authentication on Debian with Apache and NGINX

### DIFF
--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -7,10 +7,14 @@ include:
   - letsencrypt.client.domain
 
 {%- if client.source.engine == 'pkg' %}
+{% set extra_packages = [] %}
+{% if client.auth.method in ("apache", "nginx") %}
+    {% set extra_packages = client.source.get("pkgs_" + client.auth.method, []) %}
+{% endif %}
 
 certbot_packages:
   pkg.installed:
-    - names: {{ client.source.pkgs }}
+    - names: {{ client.source.pkgs + extra_packages }}
     - watch_in:
       - cmd: certbot_installed
 

--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -5,6 +5,10 @@ Debian:
     engine: pkg
     pkgs:
       - certbot
+    pkgs_apache:
+      - python-certbot-apache
+    pkgs_nginx:
+      - python-certbot-nginx
     cli: certbot
   conf_dir: /etc/letsencrypt
   auth:


### PR DESCRIPTION
~~Add python-certbot-apache package to enable Certbot apache plugin.~~
Add relevant packages to enable Certbot plugins fo Apache and NGINX web servers.