### PR TITLE
Reissue certificate for new alterntive domains

### DIFF
--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -15,6 +15,7 @@ Debian:
     method: standalone
     type: http-01
     port: 9999
+  pkg_openssl: openssl
 default:
   source:
     engine: url
@@ -25,6 +26,7 @@ default:
     method: standalone
     type: http-01
     port: 9999
+  pkg_openssl: openssl
 {%- endload %}
 
 {%- set client = salt['grains.filter_by'](base_defaults, merge=salt['pillar.get']('letsencrypt:client')) %}


### PR DESCRIPTION
Modify certificate issueing logic to reissue (expand) certificate when new (additional) domains are declared in 'names' pillar variable.

Check Subject Alternative Name certificate field using `openssl` command line utility to determine if certificate needed to be reissued.

Make sure openssl utility is installed.