### PR TITLE
filter grain by os instead of default os_family

### DIFF
--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -29,4 +29,5 @@ default:
   pkg_openssl: openssl
 {%- endload %}
 
-{%- set client = salt['grains.filter_by'](base_defaults, merge=salt['pillar.get']('letsencrypt:client')) %}
+{%- set client = salt['grains.filter_by'](base_defaults, grain='os', merge=salt['pillar.get']('letsencrypt:client')) %}
+


### PR DESCRIPTION
Hi,

using the formula on Ubuntu without installed certbot ppa and therefore using url source engine installation: 
```YAML
letsencrypt:
  client:
    source:
      engine: url
```
the merging of the map.jinja is not correct. The formula always takes cli-value from the Debian definition, instead of `cli: /usr/local/bin/certbot` from the default definition. This doesn't work and the wget download of the certbot fails

This pull request is fixing this problem. BUT - I've not tested if it works now on Debian ;-)