### PR TITLE
Add `install_units` option to install Systemd units even when `method: pkg`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ There are 3 installation methods available:
 
   If the ``certbot`` package doesn't include Systemd ``.service`` and
   ``.timer`` files, you can set them to be installed by this formula by
-  supplying ``install_units: True``.
+  supplying ``install_units: True`` and ``cli``.
 
   .. code-block:: yaml
 
@@ -36,7 +36,8 @@ There are 3 installation methods available:
         client:
           source:
             engine: pkg
-            install_units: True
+            cli: /usr/bin/certbot
+            install_units: true
 
 - URL to certbot-auto (default)
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,18 @@ There are 3 installation methods available:
           source:
             engine: pkg
 
+  If the ``certbot`` package doesn't include Systemd ``.service`` and
+  ``.timer`` files, you can set them to be installed by this formula by
+  supplying ``install_units: True``.
+
+  .. code-block:: yaml
+
+      letsencrypt:
+        client:
+          source:
+            engine: pkg
+            install_units: True
+
 - URL to certbot-auto (default)
 
   This is default installation method for systems with no available certbot

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -61,7 +61,7 @@ certbot_installed:
 
 {%- if grains.get('init', None) == 'systemd' %}
 
-{%- if client.source.engine != 'pkg' %}
+{%- if client.source.engine != 'pkg' or client.source.install_units %}
 certbot_service:
   file.managed:
     - name: /etc/systemd/system/certbot.service


### PR DESCRIPTION
The Ubuntu 16.10 Yakkety package for certbot fails to include `certbot.service` and `certbot.timer`. I wanted the utility installed by the package, but for the units files to be installed by the formula. This PR adds an option to do so.