### PR TITLE
Support meta-data fix

### DIFF
--- a/metadata/service/support.yml
+++ b/metadata/service/support.yml
@@ -1,5 +1,5 @@
 parameters:
-  leonardo:
+  letsencrypt:
     _support:
       collectd:
         enabled: false


### PR DESCRIPTION
In `metadata/service/support.yml` there must be `letsencrypt` instead of `leonardo` otherwise Saltstack will fail because it will try to find `leonardo` package/formula.