### PR TITLE
Manual DNS Auth and Deploy Hook

### DIFF
--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -25,7 +25,7 @@ certbot_{{ domain }}:
     - name: >
         certbot certonly {{ staging }} --non-interactive --agree-tos --no-self-upgrade --email {{ params.email|default(client.email) }}
         {%- if auth.method == 'standalone' %}
-        --standalone --standalone-supported-challenges {{ auth.type }} --http-01-port {{ auth.port }}
+        --standalone --preferred-challenges {{ auth.type }} --http-01-port {{ auth.port }}
         {%- elif auth.method == 'webroot' %}
         --webroot --webroot-path {{ auth.path }}
         {%- elif auth.method in ['apache', 'nginx'] %}

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -36,6 +36,9 @@ certbot_{{ domain }}:
         -d {{ d }}
         {%- endfor %}
         --expand
+        {%- if client.hook %}
+        --deploy-hook /usr/local/lib/certbot/hooks/deploy-hook
+        {%- endif %}
     {#- Check if there are missing cert file or it has missing domains, to (re)issue certificate. #}
     {#- Please note only expanding certificate (adding domains) works. #}
     - unless: test -e "{{ cert_path }}" && openssl x509 -text -in "{{ cert_path }}" | fgrep -q -e"{{ subject_alternative_names }}"

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -30,6 +30,8 @@ certbot_{{ domain }}:
         --webroot --webroot-path {{ auth.path }}
         {%- elif auth.method in ['apache', 'nginx'] %}
         --{{ auth.method }}
+        {%- elif auth.method == 'manual' %}
+        --manual --manual-public-ip-logging-ok --preferred-challenges {{ auth.type }} --manual-auth-hook /usr/local/lib/certbot/hooks/manual-auth-hook --manual-cleanup-hook /usr/local/lib/certbot/hooks/manual-cleanup-hook
         {%- endif %}
         -d {{ main_domain }}
         {%- for d in params.get('names', []) %}

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -31,7 +31,7 @@ certbot_{{ domain }}:
         {%- elif auth.method in ['apache', 'nginx'] %}
         --{{ auth.method }}
         {%- elif auth.method == 'manual' %}
-        --manual --manual-public-ip-logging-ok --preferred-challenges {{ auth.type }} --manual-auth-hook /usr/local/lib/certbot/hooks/manual-auth-hook --manual-cleanup-hook /usr/local/lib/certbot/hooks/manual-cleanup-hook
+        --manual --manual-public-ip-logging-ok --preferred-challenges {{ auth.type }} --manual-auth-hook /etc/letsencrypt/custom-hooks/manual-auth-hook --manual-cleanup-hook /etc/letsencrypt/custom-hooks/manual-cleanup-hook
         {%- endif %}
         -d {{ main_domain }}
         {%- for d in params.get('names', []) %}
@@ -39,7 +39,7 @@ certbot_{{ domain }}:
         {%- endfor %}
         --expand
         {%- if client.hook %}
-        --deploy-hook /usr/local/lib/certbot/hooks/deploy-hook
+        --deploy-hook /etc/letsencrypt/custom-hooks/deploy-hook
         {%- endif %}
     {#- Check if there are missing cert file or it has missing domains, to (re)issue certificate. #}
     {#- Please note only expanding certificate (adding domains) works. #}

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -118,6 +118,50 @@ certbot_deploy_hook:
         - makedirs: True
         - require:
             - cmd: certbot_installed
+        {%- for domain, params in client.get('domain', {}).iteritems() %}
+        {%- if client.hook %}
+        - require_in:
+            - cmd: certbot_{{ domain }}
+        {%- endif %}
+        {%- endfor %}
+{%- endif %}
+
+{%- if client.auth.method == 'manual' %}
+cerbot_manual_auth_hook:
+    file.managed:
+        - name: /usr/local/lib/certbot/hooks/manual-auth-hook
+        - source: {{ client.auth.hooks.auth }}
+        - mode: "0755"
+        - template: jinja
+        - makedirs: true
+        {%- for domain, params in client.get('domain', {}).iteritems() %}
+        {%- if params.get('enabled', true) %}
+        {%- set auth = params.auth|default(client.auth) %}
+        {%- if auth.method == 'manual' %}
+        - require_in:
+            - cmd: certbot_{{ domain }}
+        {%- endif %}
+        {%- endif %}
+        {%- endfor %}
+
+cerbot_manual_cleanup_hook:
+    file.managed:
+        - name: /usr/local/lib/certbot/hooks/manual-cleanup-hook
+        - source: {{ client.auth.hooks.cleanup }}
+        - mode: "0755"
+        - template: jinja
+        - makedirs: true
+        - require:
+            - cmd: certbot_installed     
+        {%- for domain, params in client.get('domain', {}).iteritems() %}
+        {%- if params.get('enabled', true) %}
+        {%- set auth = params.auth|default(client.auth) %}
+        {%- if auth.method == 'manual' %}
+        - require_in:
+            - cmd: certbot_{{ domain }}
+        {%- endif %}
+        {%- endif %}
+        {%- endfor %}
 {%- endif %}
 
 {%- endif %}

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -115,6 +115,7 @@ certbot_deploy_hook:
         - source: {{ client.hook }}
         - mode: "0755"
         - template: jinja
+        - makedirs: True
         - require:
             - cmd: certbot_installed
 {%- endif %}

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -111,7 +111,7 @@ certbot_cron:
 {%- if client.hook %}
 certbot_deploy_hook:
     file.managed:
-        - name: /usr/local/lib/certbot/hooks/deploy-hook
+        - name: /etc/letsencrypt/custom-hooks/deploy-hook
         - source: {{ client.hook }}
         - mode: "0755"
         - template: jinja
@@ -129,7 +129,7 @@ certbot_deploy_hook:
 {%- if client.auth.method == 'manual' %}
 cerbot_manual_auth_hook:
     file.managed:
-        - name: /usr/local/lib/certbot/hooks/manual-auth-hook
+        - name: /etc/letsencrypt/custom-hooks/manual-auth-hook
         - source: {{ client.auth.hooks.auth }}
         - mode: "0755"
         - template: jinja
@@ -146,7 +146,7 @@ cerbot_manual_auth_hook:
 
 cerbot_manual_cleanup_hook:
     file.managed:
-        - name: /usr/local/lib/certbot/hooks/manual-cleanup-hook
+        - name: /etc/letsencrypt/custom-hooks/manual-cleanup-hook
         - source: {{ client.auth.hooks.cleanup }}
         - mode: "0755"
         - template: jinja

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -102,9 +102,21 @@ certbot_cron:
   file.managed:
     - name: /etc/cron.d/certbot
     - source: salt://letsencrypt/files/cron
+    - template: jinja
     - require:
       - cmd: certbot_installed
 
+{%- endif %}
+
+{%- if client.hook %}
+certbot_deploy_hook:
+    file.managed:
+        - name: /usr/local/lib/certbot/hooks/deploy-hook
+        - source: {{ client.hook }}
+        - mode: "0755"
+        - template: jinja
+        - require:
+            - cmd: certbot_installed
 {%- endif %}
 
 {%- endif %}

--- a/letsencrypt/files/certbot
+++ b/letsencrypt/files/certbot
@@ -39,6 +39,9 @@ VOLUMES="$VOLUMES -v {{ client.auth.path|default('/var/www') }}:{{ client.auth.p
 VOLUMES="$VOLUMES -v {{ domain.auth.path|default('/var/www') }}:{{ domain.auth.path|default('/var/www') }}"
 {%- endif %}
 {%- endfor %}
+{%- if client.hook %}
+VOLUMES="$VOLUMES -v /usr/local/lib/certbot/hooks/deploy-hook:/usr/local/lib/certbot/hooks/deploy-hook"
+{%- endif %}
 
 # Only allocate tty if we detect one
 if [ -t 1 ]; then

--- a/letsencrypt/files/certbot.service
+++ b/letsencrypt/files/certbot.service
@@ -11,5 +11,5 @@ Documentation=https://letsencrypt.readthedocs.io/en/latest/
 
 [Service]
 Type=oneshot
-ExecStart={{ client.source.cli }} --no-self-upgrade -q renew
+ExecStart={{ client.source.cli }} --no-self-upgrade -q renew {% if client.hook %}--deploy-hook /usr/local/lib/certbot/hooks/deploy-hook{% endif %}
 PrivateTmp=true

--- a/letsencrypt/files/cron
+++ b/letsencrypt/files/cron
@@ -14,4 +14,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-0 */12 * * * root test -x $(which certbot) -a \! -d /run/systemd/system && perl -e 'sleep int(rand(3600))' && certbot -q renew
+0 */12 * * * root test -x $(which certbot) -a \! -d /run/systemd/system && perl -e 'sleep int(rand(3600))' && certbot -q renew {% if client.hook %}--deploy-hook /usr/local/lib/certbot/hooks/deploy-hook{% endif %}

--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -11,6 +11,7 @@ Debian:
       - python-certbot-nginx
     cli: certbot
   conf_dir: /etc/letsencrypt
+  hook: False
   auth:
     method: standalone
     type: http-01
@@ -22,6 +23,7 @@ default:
     url: "https://dl.eff.org/certbot-auto"
     cli: /usr/local/bin/certbot
   conf_dir: /etc/letsencrypt
+  hook: False
   auth:
     method: standalone
     type: http-01


### PR DESCRIPTION
This adds support for a deploy hook to all custom deployment of certificates as well as support for Certbot's manual authorization method with hooks.