### PR TITLE
Fix list concatenation for 2018.3 releases 

### DIFF
--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -18,7 +18,7 @@ certbot_packages_openssl:
 
 certbot_packages:
   pkg.installed:
-    - names: {{ (client.source.pkgs + extra_packages) | tojson }}
+    - names: {{ (client.source.pkgs + extra_packages) | json }}
     - watch_in:
       - cmd: certbot_installed
 

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -18,7 +18,7 @@ certbot_packages_openssl:
 
 certbot_packages:
   pkg.installed:
-    - names: {{ client.source.pkgs + extra_packages }}
+    - names: {{ (client.source.pkgs + extra_packages) | tojson }}
     - watch_in:
       - cmd: certbot_installed
 


### PR DESCRIPTION
Per https://github.com/saltstack/salt/issues/47001, change the list concatenation of packages to use a `json` filter so the package names don't get prefixed with 'u.


Change in salt is documented here: https://github.com/saltstack/salt/pull/49731/files