### PR TITLE
support deploy_hook setting for domain

### DIFF
--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -31,6 +31,9 @@ certbot_{{ domain }}:
         {%- elif auth.method in ['apache', 'nginx'] %}
         --{{ auth.method }}
         {%- endif %}
+        {%- if params.get('deploy_hook', None) %}
+        --deploy-hook '{{ params.deploy_hook }}'
+        {%- endif %}
         -d {{ main_domain }}
         {%- for d in params.get('names', []) %}
         -d {{ d }}


### PR DESCRIPTION
Adds support to run certbot command with --deploy-hook argument

```
letsencrypt:
  client:
    domain:
      dummy.org:
        enabled: true
        deploy_hook: script_path
```